### PR TITLE
Make pywrapfst optional.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,6 @@ Prerequisites:
 --------------
   - HTK (Tested with HCopy, HBuild and HVite version 3.5 beta (2))
   - Anaconda (Tested with Miniconda3-4.2.11-Linux-x86_64)
-  - pywrapfst (Tested with OpenFst version 1.5.4)
 
 HTK installation:
 -----------------
@@ -49,11 +48,17 @@ new environement, so you need a writeable anaconda installation:
   % cd "$amdtk_root"
   % ./install.sh -p $amdtk_root/tools/miniconda3
 
+Optional requirements:
+----------------------
+  - pywrapfst (Tested with OpenFst version 1.5.4)
+
 pywrapfst installation:
 -----------------------
-After installing 'amdtk', pywrapfst (an openfst interface for python) has to be
-installed into the created environment. If you are using your own Anaconda
-environment, you will have to change "$amdtk_root/tools/miniconda3":
+After installing 'amdtk', pywrapfst (an openfst interface for python) can be
+installed into the created environment. It is not actively used and not needed
+to run 'amdtk'. It is only imported within unused internal functions. Install
+pywrapfst only if you want to try out those functions. If you are using your own
+Anaconda environment, you will have to change "$amdtk_root/tools/miniconda3":
   % cd "$amdtk_root/tools"
   % wget http://openfst.org/twiki/pub/FST/FstDownload/openfst-1.5.4.tar.gz
   % tar -xzf openfst-1.5.4.tar.gz

--- a/amdtk/core/lm_controller.py
+++ b/amdtk/core/lm_controller.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import string
-import pywrapfst as fst
 from ..models.hpyp import EMPTY_CONTEXT
 from ..models.hpyp import VOCAB_START
 from ..models.hierarchical_language_model import SPECIAL_VOCAB
@@ -360,6 +359,9 @@ def samplePathFromFst(fst_lattice, id2label):
         Sequence of (human readable) labels.
 
     """
+    # Make the import here only as some people may not have openfst installed.
+    import pywrapfst as fst
+
     # Transform fst_lattice into a stochastic FST.
     stoc_fst_lattice = fst.push(fst_lattice, push_weights=True,
                                 remove_total_weight=True)


### PR DESCRIPTION
Hi,

since pywrapfst is not actively used in the current implementation and recipes, I moved it to the optional install instructions. Therefore the only external requirements are Anaconda and HTK for now. It is only present in the functions:

 - toFst (hmm graph class)
 - samplePathFromFst (lm controller module)
 - readHtkLattice (internal io module)

I also adjusted samplePathFromFst so pywrapfst would only be imported when calling the function.

One could move most fst functions into a dedicated fst module in the future. But right now I don't want to mess with the code to much since we are not yet using those functions and changes would only be virtual and untested.


   Oliver