### PR TITLE
Fix extract features

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,9 +10,8 @@ Prerequisites:
   - HTK (Tested with HCopy, HBuild and HVite version 3.5 beta (2))
   - Anaconda (Tested with Miniconda3-4.2.11-Linux-x86_64)
   - pywrapfst (Tested with OpenFst version 1.5.4)
-  - sox (Tested with sox version 14.4.2)
 
-HTK instalation:
+HTK installation:
 -----------------
 The tools HCopy, HBuild and HVite from the HTK distribution are needed for
 feature extraction and lattice creation. If you have HTK 3.4.1 installed, it
@@ -29,19 +28,7 @@ Make sure that you add "$amdtk_root/tools/htk/HTKTools" to your PATH variable
 prior to installing 'amdtk'.
   % PATH="$PATH:$amdtk_root/tools/htk/HTKTools"
   
-sox instalation:
-----------------
-  % cd "$amdtk_root/tools"
-  % wget https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.bz2
-  % cd sox-14.4.2
-  % ./configure --prefix="$amdtk_root/tools/sox-14.4.2"
-  % make
-  % make install
-Make sure that you add "$amdtk_root/tools/sox-14.4.2/bin" to your PATH variable
-prior to installing 'amdtk'.
-  % PATH="$PATH:$amdtk_root/tools/sox-14.4.2/bin"
-
-Anaconda instalation:
+Anaconda installation:
 ----------------------
 You need an Anaconda installation which allows you to create an own evironment.
 If you don't have Anaconda installed, you can use miniconda. Also make sure
@@ -77,3 +64,24 @@ environment, you will have to change "$amdtk_root/tools/miniconda3":
   % ./configure --enable-python --prefix="$amdtk_root/tools/miniconda3/envs/py35_amdtk"
   % make
   % make install
+
+Optional requirements:
+----------------------
+  - sox (Tested with sox version 14.4.2)
+
+sox installation:
+----------------
+sox is the Swiss Army knife of sound processing programs and can be used for
+multiple tasks. It is not actively used and not needed to run 'amdtk'. It is
+only used in the 'extract_features.sh' script to cut out segments of a wav file.
+Install sox only if you want to use that feature. See 'extract_features.sh' for
+the usage in that case. If you don't have sox installed, install it as follows:
+  % cd "$amdtk_root/tools"
+  % wget https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.bz2
+  % cd sox-14.4.2
+  % ./configure --prefix="$amdtk_root/tools/sox-14.4.2"
+  % make
+  % make install
+Make sure that you add "$amdtk_root/tools/sox-14.4.2/bin" to your PATH variable
+prior to installing 'amdtk'.
+  % PATH="$PATH:$amdtk_root/tools/sox-14.4.2/bin"

--- a/INSTALL
+++ b/INSTALL
@@ -10,8 +10,9 @@ Prerequisites:
   - HTK (Tested with HCopy, HBuild and HVite version 3.5 beta (2))
   - Anaconda (Tested with Miniconda3-4.2.11-Linux-x86_64)
   - pywrapfst (Tested with OpenFst version 1.5.4)
+  - sox (Tested with sox version 14.4.2)
 
-HTK installation:
+HTK instalation:
 -----------------
 The tools HCopy, HBuild and HVite from the HTK distribution are needed for
 feature extraction and lattice creation. If you have HTK 3.4.1 installed, it
@@ -26,9 +27,21 @@ Download HTK 3.5 beta (2) from http://htk.eng.cam.ac.uk/download.shtml into
   % make -f MakefileCPU
 Make sure that you add "$amdtk_root/tools/htk/HTKTools" to your PATH variable
 prior to installing 'amdtk'.
-  PATH="$PATH:$amdtk_root/tools/htk/HTKTools"
+  % PATH="$PATH:$amdtk_root/tools/htk/HTKTools"
+  
+sox instalation:
+----------------
+  % cd "$amdtk_root/tools"
+  % wget https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.bz2
+  % cd sox-14.4.2
+  % ./configure --prefix="$amdtk_root/tools/sox-14.4.2"
+  % make
+  % make install
+Make sure that you add "$amdtk_root/tools/sox-14.4.2/bin" to your PATH variable
+prior to installing 'amdtk'.
+  % PATH="$PATH:$amdtk_root/tools/sox-14.4.2/bin"
 
-Anaconda installation:
+Anaconda instalation:
 ----------------------
 You need an Anaconda installation which allows you to create an own evironment.
 If you don't have Anaconda installed, you can use miniconda. Also make sure

--- a/recipes/timit/utils/extract_features.sh
+++ b/recipes/timit/utils/extract_features.sh
@@ -30,26 +30,27 @@ t_end=`echo $audio | cut -d'[' -sf3`
 audio=`echo $audio | cut -d'[' -f1`
 
 # If the audio file has NIST SPHERE format convert it to WAV format.
+if test -n "`file $audio | grep symbolic`"
+then
+    audio=`readlink -f $audio`
+fi
+
 if test -n "`file $audio | grep SPHERE`" 
-    then
+then
     if [ ! -z $t_start ] && [ ! -z $t_end ]
-        then
+    then
         sph2pipe -f wav -t ${t_start}:${t_end} $audio $tmp/audio.wav
     else
         sph2pipe -f wav $audio $tmp/audio.wav 
     fi
-elif test -n "`file $audio | grep symbolic`"
-    then
-    audio=`readlink -f $audio`
-    if [ ! -z $t_start ] && [ ! -z $t_end ]
-        then
-        sph2pipe -f wav -t ${t_start}:${t_end} $audio $tmp/audio.wav
-    else
-        sph2pipe -f wav $audio $tmp/audio.wav
-    fi
 else
-    cp $audio $tmp/audio.wav
-    chmod u+w $tmp/audio.wav
+    if [ ! -z $t_start ] && [ ! -z $t_end ]
+    then
+      sox $audio $tmp/audio.wav trim ${t_start} =${t_end}
+    else
+      cp $audio $tmp/audio.wav
+      chmod u+w $tmp/audio.wav
+    fi
 fi
 
 


### PR DESCRIPTION
Hi,

I added a little fix to the 'extract_features.sh'. The checking for symbolic links looked a bit awkward so I changed it to first check for a link and reassign the path to the actual audio file and then process with checking for sph or wav files.
I also added splitting of wav files by using sox. This adds sox as an optional requirement to the install instructions. Although I guess most people will have it installed anyway (well, we did not have it on the cluster).
Eventually sox could be used for other preprocessing steps, e. g. converting from other formats or re-sampling.

   Oliver